### PR TITLE
Add two more "in post" ctas and remove end-of-article cta

### DIFF
--- a/dynamic-ctas/dynamic_ctas.php
+++ b/dynamic-ctas/dynamic_ctas.php
@@ -78,12 +78,16 @@ function nbrdcta_settings_field_callback($settings_name, $category_name)
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_sticky_header' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[sticky_header]' type='text' >" . esc_attr($category_options['sticky_header'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_in_post''>In Post</label>
+        <label for='" . "$category_id" . "_field_in_post''>1st In Post</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[in_post]' type='text' >" . esc_attr($category_options['in_post'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_article_end''>Article End</label>
-        <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_article_end' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[article_end]' type='text' >" . esc_attr($category_options['article_end'] ?? "") . "</textarea>
+        <label for='" . "$category_id" . "_field_2_in_post''>2nd In Post</label>
+        <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_2_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[2_in_post]' type='text' >" . esc_attr($category_options['2_in_post'] ?? "") . "</textarea>
+      </div>
+      <div style='display:flex;flex-direction:column'>
+        <label for='" . "$category_id" . "_field_3_in_post''>3rd In Post</label>
+        <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_3_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[3_in_post]' type='text' >" . esc_attr($category_options['3_in_post'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
         <label for='" . "$category_id" . "_field_above_footer''>Above Footer</label>
@@ -103,7 +107,9 @@ function nbrdcta_settings_field_callback($settings_name, $category_name)
 function nbrdcta_add_handlers()
 {
   add_action('csco_header_after', 'nbrdcta_handle_sticky_widget', 100);
-  add_filter('the_content', 'nbrdcta_handle_cta_body', 100);
+  /*add_filter('the_content', 'nbrdcta_handle_cta_body', 100);
+  add_filter('the_content', 'nbrdcta_handle_2_cta_body', 100);
+  add_filter('the_content', 'nbrdcta_handle_3_cta_body', 100);*/
   add_action('csco_entry_content_after', 'nbrdcta_handle_cta_content_end', 100);
   add_action('csco_footer_before', 'nbrdcta_handle_cta_pre_footer', 100);
 }
@@ -116,14 +122,14 @@ add_action('after_setup_theme', 'nbrdcta_add_handlers', 150);
 function nbrdcta_handle_cta_body($content)
 {
   $settings_key = 'in_post';
-  $num_headings = 2;
-  $insert_html = nbrdcta_get_custom_html($settings_key);
-  if (!$insert_html) {
+  $num_headings = 4;
+  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
+  if (!$insert_html_1) {
     return $content;
   }
-  $insert_html = <<<EOD
+  $insert_html_1 = <<<EOD
     <div id="in-post">
-      $insert_html
+      $insert_html_1
     </div>
   EOD;
 
@@ -137,20 +143,136 @@ function nbrdcta_handle_cta_body($content)
 
   $addition_doc = new DOMDocument;
   // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$addition_doc->loadHTML($insert_html);
+  $succeeded = @$addition_doc->loadHTML($insert_html_1);
   if (!$succeeded) {
     return $content;
   }
 
   $xpath = new DOMXpath($dom);
-  $headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
+  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
+  $headings = $xpath->query('//h2');
+  if ($headings->length <= $num_headings) {
+    $headings = $xpath->query('//h2 | //h3');
+  }
+  
+  echo $headings->length;
+  echo $first_insert  = intval(( $headings->length * 25) /  100);
+  $second_insert = intval(( $headings->length * 55) /  100);
+  $third_insert  = intval(( $headings->length * 85) /  100);
+
+  
+
   if ($headings->length >= $num_headings) {
-    $element = $headings->item($num_headings);
+    $element = $headings->item($first_insert);
     $element->parentNode->insertBefore(
       $dom->importNode($addition_doc->documentElement, true),
       $element
     );
   }
+
+  return $dom->saveHTML();
+}
+
+/*
+* Handle adding CTA to post body
+*/
+function nbrdcta_handle_2_cta_body($content)
+{
+  $settings_key = '2_in_post';
+  $num_headings = 4;
+  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
+  if (!$insert_html_1) {
+    return $content;
+  }
+  $insert_html_1 = <<<EOD
+    <div id="in-post">
+      $insert_html_1
+    </div>
+  EOD;
+
+  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
+  $dom = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$dom->loadHTML($html);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $addition_doc = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$addition_doc->loadHTML($insert_html_1);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $xpath = new DOMXpath($dom);
+  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
+  $headings = $xpath->query('//h2');
+  if ($headings->length <= $num_headings) {
+    $headings = $xpath->query('//h2 | //h3');
+  }
+  
+  $first_insert  = intval(( $headings->length * 25) /  100);
+  $second_insert = intval(( $headings->length * 55) /  100);
+  $third_insert  = intval(( $headings->length * 85) /  100);
+
+  $element = $headings->item($second_insert);
+  $element->parentNode->insertBefore(
+    $dom->importNode($addition_doc->documentElement, true),
+    $element
+  );
+
+  return $dom->saveHTML();
+}
+
+/*
+* Handle adding CTA to post body
+*/
+function nbrdcta_handle_3_cta_body($content)
+{
+  $settings_key = '3_in_post';
+  $num_headings = 4;
+  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
+  if (!$insert_html_1) {
+    return $content;
+  }
+  $insert_html_1 = <<<EOD
+    <div id="in-post">
+      $insert_html_1
+    </div>
+  EOD;
+
+  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
+  $dom = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$dom->loadHTML($html);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $addition_doc = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$addition_doc->loadHTML($insert_html_1);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $xpath = new DOMXpath($dom);
+  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
+  $headings = $xpath->query('//h2');
+  if ($headings->length <= $num_headings) {
+    $headings = $xpath->query('//h2 | //h3');
+  }
+  
+  $first_insert  = intval(( $headings->length * 25) /  100);
+  $second_insert = intval(( $headings->length * 55) /  100);
+  $third_insert  = intval(( $headings->length * 85) /  100);
+
+  $element = $headings->item($third_insert);
+  $element->parentNode->insertBefore(
+    $dom->importNode($addition_doc->documentElement, true),
+    $element
+  );
 
   return $dom->saveHTML();
 }

--- a/dynamic-ctas/dynamic_ctas.php
+++ b/dynamic-ctas/dynamic_ctas.php
@@ -74,27 +74,27 @@ function nbrdcta_settings_field_callback($settings_name, $category_name)
   return function () use ($settings_name, $category_options, $category_id) {
     echo "<div style='width:100%;display:flex;flex-direction:row;justify-content:space-between'>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_sticky_header''>Sticky Header</label>
+        <label for='" . "$category_id" . "_field_sticky_header'>Sticky Header</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_sticky_header' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[sticky_header]' type='text' >" . esc_attr($category_options['sticky_header'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_in_post''>1st In Post</label>
+        <label for='" . "$category_id" . "_field_in_post'>1st In Post</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[in_post]' type='text' >" . esc_attr($category_options['in_post'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_2_in_post''>2nd In Post</label>
+        <label for='" . "$category_id" . "_field_2_in_post'>2nd In Post</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_2_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[2_in_post]' type='text' >" . esc_attr($category_options['2_in_post'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_3_in_post''>3rd In Post</label>
+        <label for='" . "$category_id" . "_field_3_in_post'>3rd In Post</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_3_in_post' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[3_in_post]' type='text' >" . esc_attr($category_options['3_in_post'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_above_footer''>Above Footer</label>
+        <label for='" . "$category_id" . "_field_above_footer'>Above Footer</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_above_footer' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[above_footer]' type='text' >" . esc_attr($category_options['above_footer'] ?? "") . "</textarea>
       </div>
       <div style='display:flex;flex-direction:column'>
-        <label for='" . "$category_id" . "_field_search_widget''>Search Widget</label>
+        <label for='" . "$category_id" . "_field_search_widget'>Search Widget</label>
         <textarea style='resize:both' rows='5' id='" . "$category_id" . "_field_search_widget' name='" . "$settings_name" . "[" . "$category_id" . "]" . "[search_widget]' type='text' >" . esc_attr($category_options['search_widget'] ?? "") . "</textarea>
       </div>
     </div>";
@@ -107,192 +107,96 @@ function nbrdcta_settings_field_callback($settings_name, $category_name)
 function nbrdcta_add_handlers()
 {
   add_action('csco_header_after', 'nbrdcta_handle_sticky_widget', 100);
-  /*add_filter('the_content', 'nbrdcta_handle_cta_body', 100);
+  add_filter('the_content', 'nbrdcta_handle_1_cta_body', 100);
   add_filter('the_content', 'nbrdcta_handle_2_cta_body', 100);
-  add_filter('the_content', 'nbrdcta_handle_3_cta_body', 100);*/
-  add_action('csco_entry_content_after', 'nbrdcta_handle_cta_content_end', 100);
+  add_filter('the_content', 'nbrdcta_handle_3_cta_body', 100);
   add_action('csco_footer_before', 'nbrdcta_handle_cta_pre_footer', 100);
 }
 // Priority for the child theme load is 99, set to 150 to execute after child theme is loaded
 add_action('after_setup_theme', 'nbrdcta_add_handlers', 150);
 
-/*
-* Handle adding CTA to post body
-*/
-function nbrdcta_handle_cta_body($content)
+/**
+ * Handle adding 1st CTA to post body
+ */
+function nbrdcta_handle_1_cta_body($content)
 {
-  $settings_key = 'in_post';
-  $num_headings = 4;
-  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
-  if (!$insert_html_1) {
-    return $content;
-  }
-  $insert_html_1 = <<<EOD
-    <div id="in-post">
-      $insert_html_1
-    </div>
-  EOD;
-
-  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
-  $dom = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$dom->loadHTML($html);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $addition_doc = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$addition_doc->loadHTML($insert_html_1);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $xpath = new DOMXpath($dom);
-  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
-  $headings = $xpath->query('//h2');
-  if ($headings->length <= $num_headings) {
-    $headings = $xpath->query('//h2 | //h3');
-  }
-  
-  echo $headings->length;
-  echo $first_insert  = intval(( $headings->length * 25) /  100);
-  $second_insert = intval(( $headings->length * 55) /  100);
-  $third_insert  = intval(( $headings->length * 85) /  100);
-
-  
-
-  if ($headings->length >= $num_headings) {
-    $element = $headings->item($first_insert);
-    $element->parentNode->insertBefore(
-      $dom->importNode($addition_doc->documentElement, true),
-      $element
-    );
-  }
-
-  return $dom->saveHTML();
+  return nbrdcta_handle_cta_body($content, 'in_post', 0);
 }
 
-/*
-* Handle adding CTA to post body
-*/
+/**
+ * Handle adding 2nd CTA to post body
+ */
 function nbrdcta_handle_2_cta_body($content)
 {
-  $settings_key = '2_in_post';
-  $num_headings = 4;
-  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
-  if (!$insert_html_1) {
-    return $content;
-  }
-  $insert_html_1 = <<<EOD
-    <div id="in-post">
-      $insert_html_1
-    </div>
-  EOD;
+  return nbrdcta_handle_cta_body($content, '2_in_post', 1);
+}
 
-  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
-  $dom = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$dom->loadHTML($html);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $addition_doc = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$addition_doc->loadHTML($insert_html_1);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $xpath = new DOMXpath($dom);
-  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
-  $headings = $xpath->query('//h2');
-  if ($headings->length <= $num_headings) {
-    $headings = $xpath->query('//h2 | //h3');
-  }
-  
-  $first_insert  = intval(( $headings->length * 25) /  100);
-  $second_insert = intval(( $headings->length * 55) /  100);
-  $third_insert  = intval(( $headings->length * 85) /  100);
-
-  $element = $headings->item($second_insert);
-  $element->parentNode->insertBefore(
-    $dom->importNode($addition_doc->documentElement, true),
-    $element
-  );
-
-  return $dom->saveHTML();
+/**
+ * Handle adding 3rd CTA to post body
+ */
+function nbrdcta_handle_3_cta_body($content)
+{
+  return nbrdcta_handle_cta_body($content, '3_in_post', 2);
 }
 
 /*
 * Handle adding CTA to post body
 */
-function nbrdcta_handle_3_cta_body($content)
+function nbrdcta_handle_cta_body($content, $settings_key, $in_post_index)
 {
-  $settings_key = '3_in_post';
-  $num_headings = 4;
-  $insert_html_1 = nbrdcta_get_custom_html($settings_key);
-  if (!$insert_html_1) {
-    return $content;
-  }
-  $insert_html_1 = <<<EOD
-    <div id="in-post">
-      $insert_html_1
-    </div>
-  EOD;
+  $min_num_headings_for_three = 6;
+  $min_num_headings_for_all = 3;
+  $percentages = [25, 55, 85];
 
-  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
-  $dom = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$dom->loadHTML($html);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $addition_doc = new DOMDocument;
-  // The @ sign supresses warnings we are seeing. Not a permanent fix
-  $succeeded = @$addition_doc->loadHTML($insert_html_1);
-  if (!$succeeded) {
-    return $content;
-  }
-
-  $xpath = new DOMXpath($dom);
-  //$headings = $xpath->query('//h1 | //h2 | //h3 | //h4');
-  $headings = $xpath->query('//h2');
-  if ($headings->length <= $num_headings) {
-    $headings = $xpath->query('//h2 | //h3');
-  }
-  
-  $first_insert  = intval(( $headings->length * 25) /  100);
-  $second_insert = intval(( $headings->length * 55) /  100);
-  $third_insert  = intval(( $headings->length * 85) /  100);
-
-  $element = $headings->item($third_insert);
-  $element->parentNode->insertBefore(
-    $dom->importNode($addition_doc->documentElement, true),
-    $element
-  );
-
-  return $dom->saveHTML();
-}
-
-/*
-* Handle adding CTA to content end
-*/
-function nbrdcta_handle_cta_content_end()
-{
-  $settings_key = "article_end";
   $insert_html = nbrdcta_get_custom_html($settings_key);
   if (!$insert_html) {
-    return;
+    return $content;
   }
-  $container = <<<EOD
-    <div id="article-end">
+  $insert_html = <<<EOD
+    <div id="$settings_key">
       $insert_html
     </div>
   EOD;
-  echo $container;
+
+  $html = mb_convert_encoding($content, 'HTML-ENTITIES', "UTF-8");
+  $dom = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$dom->loadHTML($html);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $addition_doc = new DOMDocument;
+  // The @ sign supresses warnings we are seeing. Not a permanent fix
+  $succeeded = @$addition_doc->loadHTML($insert_html);
+  if (!$succeeded) {
+    return $content;
+  }
+
+  $xpath = new DOMXpath($dom);
+  $headings = $xpath->query('//h2');
+  if ($headings->length < $min_num_headings_for_three) {
+    $headings = $xpath->query('//h2 | //h3');
+  }
+
+  // If there are not enough headings, don't show any CTAs
+  if ($headings->length < $min_num_headings_for_all) {
+    return $content;
+  }
+
+  // If there are not enough headings for three, don't add the 1st CTA
+  if ($headings->length < $min_num_headings_for_three && $settings_key === 'in_post') {
+    return $content;
+  }
+
+  $heading_index = round($headings->length * $percentages[$in_post_index] / 100) - 1;
+  $heading_element = $headings->item($heading_index);
+  $heading_element->parentNode->insertBefore(
+    $dom->importNode($addition_doc->documentElement, true),
+    $heading_element
+  );
+
+  return $dom->saveHTML();
 }
 
 /*

--- a/dynamic-ctas/dynamic_ctas.php
+++ b/dynamic-ctas/dynamic_ctas.php
@@ -144,9 +144,10 @@ function nbrdcta_handle_3_cta_body($content)
 */
 function nbrdcta_handle_cta_body($content, $settings_key, $in_post_index)
 {
-  $min_num_headings_for_three = 6;
-  $min_num_headings_for_all = 3;
-  $percentages = [25, 55, 85];
+  $min_num_headings_for_all_three = 6;
+  $min_num_headings = 3;
+  // where to insert the 3 CTAs in the post
+  $insert_percentages = [25, 55, 85];
 
   $insert_html = nbrdcta_get_custom_html($settings_key);
   if (!$insert_html) {
@@ -175,21 +176,21 @@ function nbrdcta_handle_cta_body($content, $settings_key, $in_post_index)
 
   $xpath = new DOMXpath($dom);
   $headings = $xpath->query('//h2');
-  if ($headings->length < $min_num_headings_for_three) {
+  if ($headings->length < $min_num_headings_for_all_three) {
     $headings = $xpath->query('//h2 | //h3');
   }
 
-  // If there are not enough headings, don't show any CTAs
-  if ($headings->length < $min_num_headings_for_all) {
+  // If there are not enough headings at all, don't show any CTAs
+  if ($headings->length < $min_num_headings) {
     return $content;
   }
 
   // If there are not enough headings for three, don't add the 1st CTA
-  if ($headings->length < $min_num_headings_for_three && $settings_key === 'in_post') {
+  if ($headings->length < $min_num_headings_for_all_three && $settings_key === 'in_post') {
     return $content;
   }
 
-  $heading_index = round($headings->length * $percentages[$in_post_index] / 100) - 1;
+  $heading_index = round($headings->length * $insert_percentages[$in_post_index] / 100) - 1;
   $heading_element = $headings->item($heading_index);
   $heading_element->parentNode->insertBefore(
     $dom->importNode($addition_doc->documentElement, true),


### PR DESCRIPTION
In Post CTA Tasks
- Change “In Post” CTA name in the plugin code and plugin front-end to “1st In Post”
- Update placement logic within plugin code of “1st In Post” CTA (see logic below)
- Change “Article End” CTA name in the plugin code and plugin front-end to “2nd In Post”
- Update placement logic within plugin code of “2nd In Post” CTA (see logic below)
- Add new “3rd In Post” CTA within plugin code (see logic below)

In Post Placement Logic
1. Count the number of H2s
- If 4 or less H2s, then count H2s and H3s
2. Divide the number of previously counted headers (H2s, or H2s and H3s) by 25%, 55% and 85%. Round to the nearest whole number to get the location of each in-post CTA.
3. Using the values calculated from the prior step as the header number within an article, place the 1st, 2nd or 3rd in post CTA before the calculated header instance.